### PR TITLE
Save Photo Feature Implemented!

### DIFF
--- a/dojo-custom-camera/Base.lproj/Main.storyboard
+++ b/dojo-custom-camera/Base.lproj/Main.storyboard
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6250" systemVersion="14A388a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10089" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="vXZ-lx-hvc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6244"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10072.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -96,9 +97,4 @@
             <point key="canvasLocation" x="169" y="476"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination" type="retina4"/>
-    </simulatedMetricsContainer>
 </document>

--- a/dojo-custom-camera/XMCCameraViewController.swift
+++ b/dojo-custom-camera/XMCCameraViewController.swift
@@ -73,8 +73,12 @@ class XMCCameraViewController: UIViewController, XMCCameraDelegate {
                     self.status = .Error
                 }
                 
-                self.cameraCapture.setTitle("Reset", forState: UIControlState.Normal)
+                //Save Photo to Library
+                self.cameraCapture.setTitle("Save Photo", forState: UIControlState.Normal)
+                UIImageWriteToSavedPhotosAlbum(image!, self,
+                    "image:didFinishSavingWithError:contextInfo:", nil)
             })
+
         } else if self.status == .Still || self.status == .Error {
             UIView.animateWithDuration(0.225, animations: { () -> Void in
                 self.cameraStill.alpha = 0.0;
@@ -111,5 +115,17 @@ class XMCCameraViewController: UIViewController, XMCCameraDelegate {
             self.cameraPreview.alpha = 0.0
         })
     }
+}
+
+
+//When image is saved
+func image(image: UIImage, didFinishSavingWithError
+    error: NSErrorPointer, contextInfo:UnsafePointer<Void>) {
+        
+        if error != nil {
+            // Report error to user
+        }
+        
+        print("Got it!")
 }
 


### PR DESCRIPTION
Thought a "save photo" feature would be a nice touch!
- Once the photo is captured, the capture button's title changes to 'Save Photo', instead of 'Reset'. 
- The photo is then saved to the user's library.
- The camera then resets to it's original state, ready to capture once again.
